### PR TITLE
ebpf_gen: Fix emit_call missing from instructions generated by stack_printk/2

### DIFF
--- a/include/ebpf.hrl
+++ b/include/ebpf.hrl
@@ -73,9 +73,9 @@
 -define(BPF_TAX, 16#00).
 -define(BPF_TXA, 16#80).
 
-
 -type bpf_alu_op() ::
     '+'
+    | 'add'
     | '-'
     | '*'
     | '/'

--- a/src/ebpf_gen.erl
+++ b/src/ebpf_gen.erl
@@ -118,7 +118,15 @@ stack_printk(String) ->
 
 -spec stack_printk(string(), integer()) -> [bpf_instruction()].
 stack_printk(String, StackHead) ->
-    {Instructions, _NewStackHead} = push_string(String, StackHead),
+    {Instructions0, NewStackHead} = push_string(String, StackHead),
+    Instructions =
+        Instructions0 ++
+            [
+                mov64_reg(1, 10),
+                alu64_imm(add, 1, NewStackHead),
+                mov64_imm(2, -NewStackHead),
+                emit_call(trace_printk)
+            ],
     Instructions.
 
 -spec push_string(string()) -> {[bpf_instruction()], integer()}.

--- a/src/ebpf_gen.erl
+++ b/src/ebpf_gen.erl
@@ -324,6 +324,7 @@ bpf_helper_to_int(sock_from_file) -> 162.
 
 -spec bpf_alu_op_to_int(bpf_alu_op()) -> bpf_opcode().
 bpf_alu_op_to_int('+') -> ?BPF_ADD;
+bpf_alu_op_to_int('add') -> ?BPF_ADD;
 bpf_alu_op_to_int('-') -> ?BPF_SUB;
 bpf_alu_op_to_int('*') -> ?BPF_MUL;
 bpf_alu_op_to_int('/') -> ?BPF_DIV;


### PR DESCRIPTION
Fixes a silly bug in #5 initial implementation.