### PR TITLE
Expand ebpf_lib:verify/2

### DIFF
--- a/src/ebpf_lib.erl
+++ b/src/ebpf_lib.erl
@@ -66,7 +66,10 @@ disassemble(<<InstructionBin:8/binary-unit:8, More/binary>>, Acc) ->
 verify(BpfProgramType, BpfProgramBin) ->
     bpf_verify_program(
         bpf_prog_type_to_int(BpfProgramType),
-        BpfProgramBin
+        BpfProgramBin,
+        4096,
+        0,
+        "GPL"
     ).
 
 %%--------------------------------------------------------------------
@@ -115,8 +118,14 @@ attach_xdp(IfName, ProgFd) when is_list(IfName) ->
 %%% NIFs and NIF related functions
 %%%-------------------------------------------------------------------
 
--spec bpf_verify_program(non_neg_integer(), binary()) -> 'ok' | {'error', term()}.
-bpf_verify_program(_BpfProgramType, _BpfProgramBin) ->
+-spec bpf_verify_program(
+    non_neg_integer(),
+    binary(),
+    non_neg_integer(),
+    non_neg_integer(),
+    string()
+) -> 'ok' | {'error', atom()} | {'error', atom(), string()}.
+bpf_verify_program(_BpfProgramType, _BpfProgramBin, _LogBufferSize, _KernelVersion, _License) ->
     not_loaded(?LINE).
 
 -spec bpf_load_program(non_neg_integer(), binary()) ->

--- a/src/ebpf_lib.erl
+++ b/src/ebpf_lib.erl
@@ -62,7 +62,7 @@ disassemble(<<InstructionBin:8/binary-unit:8, More/binary>>, Acc) ->
 %% by the kernel.
 %% @end
 %%--------------------------------------------------------------------
--spec verify(bpf_prog_type(), binary()) -> 'ok' | {'error', term()}.
+-spec verify(bpf_prog_type(), binary()) -> {'ok', string()} | {'error', term()}.
 verify(BpfProgramType, BpfProgramBin) ->
     bpf_verify_program(
         bpf_prog_type_to_int(BpfProgramType),
@@ -124,7 +124,7 @@ attach_xdp(IfName, ProgFd) when is_list(IfName) ->
     non_neg_integer(),
     non_neg_integer(),
     string()
-) -> 'ok' | {'error', atom()} | {'error', atom(), string()}.
+) -> {'ok', string()} | {'error', atom()} | {'error', atom(), string()}.
 bpf_verify_program(_BpfProgramType, _BpfProgramBin, _LogBufferSize, _KernelVersion, _License) ->
     not_loaded(?LINE).
 


### PR DESCRIPTION
Improves error handling and reporting in `ebpf_lib:verify/2`.
A string representing the kernel's response is returned only in cases where the kernel's verifier actually produces one, and the `errno` is reported for all errors.

The underlying NIF's implementation is also changed to expose more `bpf(2)` parameters, setting the ground for further customization.