### PR TITLE
ebpf_user: Add test_program/4 function

### DIFF
--- a/c_src/ebpf_user.c
+++ b/c_src/ebpf_user.c
@@ -985,7 +985,7 @@ ebpf_delete_map_element2(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 static ERL_NIF_TERM
 ebpf_get_map_next_key2(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-  int fd;
+  int fd = -1;
   ErlNifBinary key = {0,};
   ERL_NIF_TERM next_key = {0,};
 
@@ -1011,6 +1011,56 @@ ebpf_get_map_next_key2(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   return enif_make_tuple2(env, mk_atom(env, "ok"), next_key);
 }
 
+static ERL_NIF_TERM
+ebpf_test_program3(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+  int prog_fd = -1;
+  int repeat = 0;
+  ErlNifBinary data = {0,};
+  void * data_out_ptr = NULL;
+  __u32 data_out_size = 0;
+  __u32 retval = 0;
+  __u32 duration = 0;
+  ERL_NIF_TERM data_out = {0,};
+
+  int res = -1;
+
+  if(argc != 3)
+    {
+      return enif_make_badarg(env);
+    }
+
+  if(!enif_get_int(       env, argv[0], &prog_fd)
+  || !enif_inspect_binary(env, argv[1], &data   )
+  || !enif_get_uint(      env, argv[2], &data_out_size))
+    {
+      return enif_make_badarg(env);
+    }
+
+  data_out_ptr = malloc(data_out_size);
+  if(data_out_ptr == NULL)
+    {
+      return mk_error(env, erl_errno_id(errno));
+    }
+  memset(data_out_ptr, 0, data_out_size);
+
+  res = bpf_prog_test_run(prog_fd,
+			  data.data,
+			  data.size,
+			  data_out_ptr,
+			  &data_out_size,
+			  &retval,
+			  &duration);
+  if (res < 0)
+    {
+      return mk_error(env, erl_errno_id(errno));
+    }
+
+  memcpy(enif_make_new_binary(env, data_out_size, &data_out), data_out_ptr, data_out_size);
+
+  return enif_make_tuple4(env, mk_atom(env, "ok"), enif_make_uint(env, retval), data_out, enif_make_uint(duration));
+}
+
 static ErlNifFunc nif_funcs[] = {
 				 {"bpf_load_program", 2, ebpf_load_program, 0},
 				 {"bpf_attach_socket_filter", 2, ebpf_attach_socket_filter, 0},
@@ -1021,7 +1071,8 @@ static ErlNifFunc nif_funcs[] = {
 				 {"bpf_update_map_element", 4, ebpf_update_map_element4, 0},
 				 {"bpf_lookup_map_element", 4, ebpf_lookup_map_element4, 0},
 				 {"bpf_delete_map_element", 2, ebpf_delete_map_element2, 0},
-				 {"bpf_get_map_next_key", 2, ebpf_get_map_next_key2, 0}
+				 {"bpf_get_map_next_key", 2, ebpf_get_map_next_key2, 0},
+				 {"bpf_test_program", 3, ebpf_test_program3, 0}
 };
 
 ERL_NIF_INIT(ebpf_user, nif_funcs, NULL, NULL, NULL, NULL);

--- a/examples/cf_ttl.erl
+++ b/examples/cf_ttl.erl
@@ -45,11 +45,11 @@ attach_ttl_bpf(SockFd) ->
     ok = ebpf_user:attach_socket_filter(SockFd, Prog),
     {ok, Map}.
 
--spec read_ttl_bpf(bpf_map()) -> 'empty' | {'ok', non_neg_integer()} | {error, term()}.
+-spec read_ttl_bpf(ebpf_user:bpf_map()) -> 'empty' | {'ok', non_neg_integer()} | {error, term()}.
 read_ttl_bpf(Map) ->
     read_ttl_bpf(Map, <<0:32>>, empty).
 
--spec read_ttl_bpf(bpf_map(), binary(), 'empty' | non_neg_integer()) ->
+-spec read_ttl_bpf(ebpf_user:bpf_map(), binary(), 'empty' | non_neg_integer()) ->
     'empty' | {'ok', non_neg_integer()} | {error, term()}.
 read_ttl_bpf(Map, Key, Min) ->
     case ebpf_user:get_map_next_key(Map, Key) of

--- a/src/ebpf_user.erl
+++ b/src/ebpf_user.erl
@@ -19,7 +19,7 @@
 %% API
 -export([
     load/2,
-    test_program/3,
+    test_program/4,
     verify/2,
     verify/3,
     create_map/5,
@@ -184,24 +184,30 @@ load(BpfProgramType, BpfProgramBin) ->
 %% @doc
 %% Performs a test run of Prog with Data as input.
 %%
-%% WARNING: Here Be Dragons!
-%% This function should only be used with trusted eBPF programs.
-%%
+%% WARNING: only use with trusted eBPF programs.
 %% This function uses the `BPF_PROG_TEST_RUN' Linux feature, which
-%% is unfortunately currently inherently unsafe as the kernel will write
-%% Data as as transformed by the operation of Prog (so called DataOut)
-%% into a userspace buffer of predetermined size, DataOutSize. In most cases
-%% this is fine because Prog wouldn't usually create extensively large
-%% DataOut, but in cases where Prog might create an output that is larger
-%% DataOutSize, this can lead to buffer overflow. Hence the warning.
+%% is unfortunately inherently unsafe if not used correctly. The way
+%% `BPF_PROG_TEST_RUN' works is that the kernel will write `DataOut',
+%% created by applying `Prog' to `Data', into a userspace buffer of some
+%% predetermined size, exposed in this function as DataOutSize.
+%% In most cases this is fine because Prog shouldn't create extensively large
+%% DataOut in normal use case, but in case where Prog might create an
+%% output that is larger DataOutSize, this can lead to buffer overflow.
+%% Hence the warning.
 %%
+%% If `DataOut' is not needed, `DataOutSize' can be safely set to `0'.
+%%
+%% On success, returns the return value of `Prog(Data)', as well as `DataOut'
+%% and the duration of the test as reported by the kernel.
 %% @end
 %%--------------------------------------------------------------------
--spec test_program(bpf_prog(), binary(), non_neg_integer()) ->
-    {'ok', non_neg_integer(), binary(), non_neg_integer()} | {'error', atom()}.
-test_program(Prog, Data, DataOutSize) ->
+-spec test_program(bpf_prog(), integer(), binary(), non_neg_integer()) ->
+    {'ok', Ret :: non_neg_integer(), DataOut :: binary(), Duration :: non_neg_integer()}
+    | {'error', atom()}.
+test_program(Prog, Repeat, Data, DataOutSize) ->
     bpf_test_program(
         Prog,
+        Repeat,
         Data,
         DataOutSize
     ).
@@ -382,9 +388,9 @@ bpf_delete_map_element(_Map, _Key) ->
 bpf_get_map_next_key(_Map, _Key) ->
     not_loaded(?LINE).
 
--spec bpf_test_program(bpf_prog(), binary(), non_neg_integer()) ->
+-spec bpf_test_program(bpf_prog(), integer(), binary(), non_neg_integer()) ->
     {'ok', non_neg_integer(), binary(), non_neg_integer()} | {'error', atom()}.
-bpf_test_program(_Prog, _Data, _DataOutSize) ->
+bpf_test_program(_Prog, _Repeat, _Data, _DataOutSize) ->
     not_loaded(?LINE).
 
 -spec bpf_close(integer()) -> {'ok'} | {'error', atom()}.

--- a/test/ebpf_SUITE.erl
+++ b/test/ebpf_SUITE.erl
@@ -173,6 +173,8 @@ groups() ->
         {ebpf_user_ct, [sequence], [
             test_user_create_map_hash_1,
             test_example_from_ebpf_kern_docs_1,
+            test_user_test_program_1,
+            test_user_test_program_2,
             simple_socket_filter_1
         ]}
     ].
@@ -265,6 +267,65 @@ test_user_create_map_hash_1(_Config) ->
         {ok, _Map} -> ok;
         {error, eperm} -> {skip, eperm};
         Other -> {error, Other}
+    end.
+
+test_user_test_program_1() -> [].
+test_user_test_program_1(_Config) ->
+    Data =
+        <<220, 166, 50, 111, 234, 102, 178, 104, 223, 17, 67, 189, 8, 0, 69, 0, 0, 60, 13, 111, 64,
+            0, 64, 6, 147, 181, 10, 3, 141, 147, 1, 1, 1, 1, 185, 218, 0, 80, 189, 122, 208, 241, 0,
+            0, 0, 0, 160, 2, 250, 240, 194, 210, 0, 0, 2, 4, 5, 180, 4, 2, 8, 10, 3, 173, 164, 96,
+            0, 0, 0, 0, 1, 3, 3, 7>>,
+
+    case
+        ebpf_user:load(
+            xdp,
+            ebpf_asm:assemble(
+                lists:flatten([
+                    ebpf_kern:mov64_imm(0, -1),
+                    ebpf_kern:exit_insn()
+                ])
+            )
+        )
+    of
+        {ok, Prog} ->
+            {ok, 16#FFFFFFFF, Data, _Duration} = ebpf_user:test_program(
+                Prog,
+                128,
+                Data,
+                byte_size(Data)
+            );
+        {error, eperm} ->
+            {skip, eperm};
+        Other ->
+            {error, Other}
+    end.
+
+test_user_test_program_2() -> [].
+test_user_test_program_2(_Config) ->
+    Data =
+        <<220, 166, 50, 111, 234, 102, 178, 104, 223, 17, 67, 189, 8, 0, 69, 0, 0, 60, 13, 111, 64,
+            0, 64, 6, 147, 181, 10, 3, 141, 147, 1, 1, 1, 1, 185, 218, 0, 80, 189, 122, 208, 241, 0,
+            0, 0, 0, 160, 2, 250, 240, 194, 210, 0, 0, 2, 4, 5, 180, 4, 2, 8, 10, 3, 173, 164, 96,
+            0, 0, 0, 0, 1, 3, 3, 7>>,
+
+    case
+        ebpf_user:load(
+            xdp,
+            ebpf_asm:assemble(
+                lists:flatten([
+                    ebpf_kern:mov64_imm(0, -1),
+                    ebpf_kern:exit_insn()
+                ])
+            )
+        )
+    of
+        {ok, Prog} ->
+            {ok, 16#FFFFFFFF, <<>>, _Duration} = ebpf_user:test_program(Prog, 128, Data, 0);
+        {error, eperm} ->
+            {skip, eperm};
+        Other ->
+            {error, Other}
     end.
 
 test_example_from_ebpf_kern_docs_1() -> [].


### PR DESCRIPTION
Add `ebpf_user:test_program/4`, which can be used to run a loaded eBPF program with an arbitrary `binary()` as the input, courtesy of `BPF_PROG_TEST_RUN` command to `bpf(2)`.
This can be generally useful and it's needed for properly testing `ebpf_kern`.