### PR TITLE
Add ebpf_user:detach_socket_filter/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,19 @@ Checkout the [examples](examples/).
 
 A minimal example is given below:
 ```erlang
-{ok, ProgFd} = ebpf_user:load(socket_filter,
+{ok, Prog} = ebpf_user:load(socket_filter,
                              ebpf_asm:assemble([
+							     % Drop all packets
                                  ebpf_kern:mov64_imm(0,0), % R0 = 0
                                  ebpf_kern:exit_insn()     % return R0
                              ])),
+
 {ok, S} = socket:open(inet, stream, {raw, 0}),
 {ok, SockFd} = socket:getopt(S, otp, fd),
-ok = ebpf_user:attach_socket_filter(SockFd, ProgFd).
+
+ok = ebpf_user:attach_socket_filter(SockFd, Prog), % All new input to S is dropped
+
+ok = ebpf_user:detach_socket_filter(SockFd). % S is back to normal and Prog can be reused
 ```
 
 For projects that build with `rebar3`, add `ebpf` as a dependency in `rebar.config`:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The current API should remain pretty stable, while it is planned to be expanded 
 Documentation
 -------------
 
-	$ rebar3 edoc
+    $ rebar3 edoc
 
 The documentation for the latest version can be browsed at https://oskardrums.github.io/ebpf/
 
@@ -44,16 +44,13 @@ A minimal example is given below:
 ```erlang
 {ok, Prog} = ebpf_user:load(socket_filter,
                              ebpf_asm:assemble([
-							     % Drop all packets
+                                 % Drop all packets
                                  ebpf_kern:mov64_imm(0,0), % R0 = 0
                                  ebpf_kern:exit_insn()     % return R0
                              ])),
-
 {ok, S} = socket:open(inet, stream, {raw, 0}),
 {ok, SockFd} = socket:getopt(S, otp, fd),
-
 ok = ebpf_user:attach_socket_filter(SockFd, Prog), % All new input to S is dropped
-
 ok = ebpf_user:detach_socket_filter(SockFd). % S is back to normal and Prog can be reused
 ```
 

--- a/c_src/ebpf_user.c
+++ b/c_src/ebpf_user.c
@@ -828,6 +828,30 @@ ebpf_attach_socket_filter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 }
 
 static ERL_NIF_TERM
+ebpf_detach_socket_filter1(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+  int sock_fd = 0, empty = 0;
+  int res = -1;
+
+  if(argc != 1)
+    {
+      return enif_make_badarg(env);
+    }
+
+  if(!enif_get_int(env, argv[0], &sock_fd))
+    {
+      return mk_error(env, "bad_sock_fd");
+    }
+
+  res = setsockopt(sock_fd, SOL_SOCKET, SO_DETACH_BPF, &empty, sizeof(empty));
+  if (res < 0) {
+    return mk_error(env, erl_errno_id(errno));
+  }
+
+  return mk_atom(env, "ok");
+}
+
+static ERL_NIF_TERM
 ebpf_create_map5(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
   int map_type = 0;
@@ -1098,6 +1122,7 @@ int ebpf_nif_lib_upgrade(ErlNifEnv* caller_env, void** priv_data, void** old_pri
 static ErlNifFunc nif_funcs[] = {
 				 {"bpf_load_program", 2, ebpf_load_program, 0},
 				 {"bpf_attach_socket_filter", 2, ebpf_attach_socket_filter, 0},
+				 {"bpf_detach_socket_filter", 1, ebpf_detach_socket_filter1, 0},
 				 {"bpf_attach_xdp", 2, ebpf_attach_xdp, 0},
 				 {"bpf_verify_program", 5, ebpf_verify_program5, 0},
 				 {"bpf_create_map", 5, ebpf_create_map5, 0},

--- a/src/ebpf_user.erl
+++ b/src/ebpf_user.erl
@@ -28,6 +28,7 @@
     delete_map_element/2,
     get_map_next_key/2,
     attach_socket_filter/2,
+    detach_socket_filter/1,
     attach_xdp/2,
     close/1
 ]).
@@ -314,6 +315,15 @@ attach_socket_filter(SockFd, ProgFd) ->
 
 %%--------------------------------------------------------------------
 %% @doc
+%% Removes the eBPF program attached to `SockFd'.
+%% @end
+%%--------------------------------------------------------------------
+-spec detach_socket_filter(non_neg_integer()) -> 'ok' | {'error', atom()}.
+detach_socket_filter(SockFd) ->
+    bpf_detach_socket_filter(SockFd).
+
+%%--------------------------------------------------------------------
+%% @doc
 %% Applies a loaded eBPF XDP program as returned by {@link load/2}
 %% with `xdp' a `BpfProgramType' to a network interface.
 %% @end
@@ -359,6 +369,10 @@ bpf_load_program(_BpfProgramType, _BpfProgramBin) ->
 
 -spec bpf_attach_socket_filter(non_neg_integer(), non_neg_integer()) -> 'ok' | {'error', atom()}.
 bpf_attach_socket_filter(_SockFd, _ProgFd) ->
+    not_loaded(?LINE).
+
+-spec bpf_detach_socket_filter(non_neg_integer()) -> 'ok' | {'error', atom()}.
+bpf_detach_socket_filter(_SockFd) ->
     not_loaded(?LINE).
 
 -spec bpf_attach_xdp(non_neg_integer(), non_neg_integer()) -> 'ok' | {'error', atom()}.

--- a/test/ebpf_SUITE.erl
+++ b/test/ebpf_SUITE.erl
@@ -248,7 +248,8 @@ simple_socket_filter_1(_Config) ->
     ),
     {ok, S} = socket:open(inet, stream, {raw, 0}),
     {ok, SockFd} = socket:getopt(S, otp, fd),
-    ok = ebpf_user:attach_socket_filter(SockFd, ProgFd).
+    ok = ebpf_user:attach_socket_filter(SockFd, ProgFd),
+    ok = ebpf_user:detach_socket_filter(SockFd).
 
 test_user_create_map_hash_1() -> [].
 test_user_create_map_hash_1(_Config) ->


### PR DESCRIPTION
Adds a method to remove a previously attached eBPF filter from a socket without `close`ing the eBPF program.