### PR TITLE
Add ebpf_maps module and move related functions from ebpf_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Erlang eBPF library
 Overview
 --------
 `ebpf` is an Erlang library for creating and interacting with eBPF programs.
-These modules are currently included:
+The following modules are currently included:
 * `ebpf_user`: load eBPF programs and use loaded programs
 * `ebpf_kern`: generate eBPF instructions according to different parameters
 * `ebpf_asm`: eBPF assembly and disassembly routines

--- a/README.md
+++ b/README.md
@@ -6,18 +6,12 @@ Erlang eBPF library
 
 Overview
 --------
-`ebpf` facilitates basic interaction with the Linux eBPF system from Erlang.
-Three modules are currently included:
-* `ebpf_user` contains NIFs that wrap the Linux native API to eBPF, ultimately calling the `bpf(2)` syscall
-* `ebpf_kern` contains functions that generate eBPF instructions according to different parameters
-* `ebpf_asm` contains eBPF assembly and disassembly routines
-
-Status
-------
-
-This library is not yet feature complete nor is it extensively tested.
-
-The current API should remain pretty stable, while it is planned to be expanded to expose more eBPF functionalities and perhaps also include a higher lever interface a la `gen_bpf`.
+`ebpf` is an Erlang library for creating and interacting with eBPF programs.
+These modules are currently included:
+* `ebpf_user`: load eBPF programs and use loaded programs
+* `ebpf_kern`: generate eBPF instructions according to different parameters
+* `ebpf_asm`: eBPF assembly and disassembly routines
+* `ebpf_maps`: userspace API to eBPF maps, mimics the Erlang/OTP `maps` interface with eBPF maps
 
 Documentation
 -------------
@@ -25,16 +19,6 @@ Documentation
     $ rebar3 edoc
 
 The documentation for the latest version can be browsed at https://oskardrums.github.io/ebpf/
-
-Build
------
-
-    $ rebar3 compile
-    
-Test
-----
-
-    $ rebar3 do ct, proper
 
 Usage
 -----
@@ -65,6 +49,17 @@ For projects that build with `rebar3`, add `ebpf` as a dependency in `rebar.conf
 ```erlang
 {deps, [{ebpf, {git, "https://github.com/oskardrums/ebpf.git", "main"}}]}.
 ```
+
+Build
+-----
+
+    $ rebar3 compile
+
+Test
+----
+
+    $ rebar3 do ct, proper
+
 
 Contributions
 ------------

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,7 +5,7 @@ BASEDIR := $(abspath $(CURDIR)/..)
 
 # PROJECT ?= $(notdir $(BASEDIR))
 # PROJECT := $(strip $(PROJECT))
-PROJECT = ebpf_user
+PROJECT = ebpf_lib
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)]).")

--- a/c_src/ebpf_lib.c
+++ b/c_src/ebpf_lib.c
@@ -1135,4 +1135,4 @@ static ErlNifFunc nif_funcs[] = {
 				 {"bpf_test_program", 4, ebpf_test_program4, 0}
 };
 
-ERL_NIF_INIT(ebpf_user, nif_funcs, ebpf_nif_lib_load, NULL, ebpf_nif_lib_upgrade, NULL);
+ERL_NIF_INIT(ebpf_lib, nif_funcs, ebpf_nif_lib_load, NULL, ebpf_nif_lib_upgrade, NULL);

--- a/c_src/ebpf_lib.c
+++ b/c_src/ebpf_lib.c
@@ -1037,6 +1037,40 @@ ebpf_get_map_next_key2(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   return enif_make_tuple2(env, mk_atom(env, "ok"), next_key);
 }
 
+
+
+static ERL_NIF_TERM
+ebpf_get_map_first_key2(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+  int fd = -1;
+  uint32_t key_size = 0;
+  ERL_NIF_TERM next_key = {0,};
+
+  int res = -1;
+
+  if(argc != 2)
+    {
+      return enif_make_badarg(env);
+    }
+
+  if(!enif_get_int(env, argv[0], &fd)
+  || !enif_get_uint(env, argv[1], &key_size))
+    {
+      return enif_make_badarg(env);
+    }
+
+  res = bpf_map_get_next_key(fd, NULL, enif_make_new_binary(env, key_size, &next_key));
+  if (res < 0)
+    {
+      return mk_error(env, erl_errno_id(errno));
+    }
+
+  return enif_make_tuple2(env, mk_atom(env, "ok"), next_key);
+}
+
+
+
+
 static ERL_NIF_TERM
 ebpf_test_program4(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -1132,6 +1166,7 @@ static ErlNifFunc nif_funcs[] = {
 				 {"bpf_lookup_map_element", 4, ebpf_lookup_map_element4, 0},
 				 {"bpf_delete_map_element", 2, ebpf_delete_map_element2, 0},
 				 {"bpf_get_map_next_key", 2, ebpf_get_map_next_key2, 0},
+				 {"bpf_get_map_first_key", 2, ebpf_get_map_first_key2, 0},
 				 {"bpf_test_program", 4, ebpf_test_program4, 0}
 };
 

--- a/src/ebpf_lib.erl
+++ b/src/ebpf_lib.erl
@@ -21,6 +21,7 @@
     bpf_lookup_map_element/4,
     bpf_delete_map_element/2,
     bpf_get_map_next_key/2,
+    bpf_get_map_first_key/2,
     bpf_test_program/4,
     bpf_close/1
 ]).
@@ -67,25 +68,29 @@ bpf_create_map(_Type, _KeySize, _ValueSize, _MaxEntries, _Flags) ->
 
 -spec bpf_update_map_element(integer(), binary(), binary(), non_neg_integer()) ->
     'ok' | {'error', atom()}.
-bpf_update_map_element(_Map, _Key, _Value, _Flags) ->
+bpf_update_map_element(_MapFd, _Key, _Value, _Flags) ->
     not_loaded(?LINE).
 
 -spec bpf_lookup_map_element(integer(), binary(), non_neg_integer(), non_neg_integer()) ->
     {'ok', binary()} | {'error', atom()}.
-bpf_lookup_map_element(_Map, _Key, _ValueSize, _Flags) ->
+bpf_lookup_map_element(_MapFd, _Key, _ValueSize, _Flags) ->
     not_loaded(?LINE).
 
 -spec bpf_delete_map_element(integer(), binary()) -> 'ok' | {'error', atom()}.
-bpf_delete_map_element(_Map, _Key) ->
+bpf_delete_map_element(_MapFd, _Key) ->
     not_loaded(?LINE).
 
 -spec bpf_get_map_next_key(integer(), binary()) -> {'ok', binary()} | {'error', atom()}.
-bpf_get_map_next_key(_Map, _Key) ->
+bpf_get_map_next_key(_MapFd, _Key) ->
+    not_loaded(?LINE).
+
+-spec bpf_get_map_first_key(integer(), non_neg_integer()) -> {'ok', binary()} | {'error', atom()}.
+bpf_get_map_first_key(_MapFd, _KeySize) ->
     not_loaded(?LINE).
 
 -spec bpf_test_program(integer(), integer(), binary(), non_neg_integer()) ->
     {'ok', non_neg_integer(), binary(), non_neg_integer()} | {'error', atom()}.
-bpf_test_program(_Prog, _Repeat, _Data, _DataOutSize) ->
+bpf_test_program(_ProgFd, _Repeat, _Data, _DataOutSize) ->
     not_loaded(?LINE).
 
 -spec bpf_close(integer()) -> 'ok' | {'error', atom()}.

--- a/src/ebpf_lib.erl
+++ b/src/ebpf_lib.erl
@@ -1,0 +1,114 @@
+%%%-------------------------------------------------------------------
+%%% @author moskar <moskar.drummer@gmail.com>
+%%% @copyright (C) 2021, moskar
+%%% @private
+%%%
+%%% eBPF NIFs
+%%%
+%%% @end
+%%% Created :  7 Feb 2021 by user <moskar.drummer@gmail.home>
+%%%-------------------------------------------------------------------
+-module(ebpf_lib).
+
+%% API
+-export([
+    bpf_load_program/5,
+    bpf_attach_socket_filter/2,
+    bpf_detach_socket_filter/1,
+    bpf_attach_xdp/2,
+    bpf_create_map/5,
+    bpf_update_map_element/4,
+    bpf_lookup_map_element/4,
+    bpf_delete_map_element/2,
+    bpf_get_map_next_key/2,
+    bpf_test_program/4,
+    bpf_close/1
+]).
+
+-on_load(init/0).
+
+-define(APPNAME, ebpf).
+-define(LIBNAME, ?MODULE).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec bpf_load_program(
+    non_neg_integer(),
+    binary(),
+    non_neg_integer(),
+    string(),
+    non_neg_integer()
+) ->
+    {'ok', non_neg_integer()}
+    | {'ok', non_neg_integer(), string()}
+    | {'error', atom()}
+    | {'error', atom(), string()}.
+bpf_load_program(_ProgType, _BinProg, _LogBufferSize, _License, _Flags) ->
+    not_loaded(?LINE).
+
+-spec bpf_attach_socket_filter(non_neg_integer(), non_neg_integer()) -> 'ok' | {'error', atom()}.
+bpf_attach_socket_filter(_SockFd, _ProgFd) ->
+    not_loaded(?LINE).
+
+-spec bpf_detach_socket_filter(non_neg_integer()) -> 'ok' | {'error', atom()}.
+bpf_detach_socket_filter(_SockFd) ->
+    not_loaded(?LINE).
+
+-spec bpf_attach_xdp(non_neg_integer(), integer()) -> 'ok' | {'error', atom()}.
+bpf_attach_xdp(_IfIndex, _ProgFd) ->
+    not_loaded(?LINE).
+
+-spec bpf_create_map(non_neg_integer(), integer(), integer(), integer(), non_neg_integer()) ->
+    {'ok', non_neg_integer()} | {'error', atom()}.
+bpf_create_map(_Type, _KeySize, _ValueSize, _MaxEntries, _Flags) ->
+    not_loaded(?LINE).
+
+-spec bpf_update_map_element(integer(), binary(), binary(), non_neg_integer()) ->
+    'ok' | {'error', atom()}.
+bpf_update_map_element(_Map, _Key, _Value, _Flags) ->
+    not_loaded(?LINE).
+
+-spec bpf_lookup_map_element(integer(), binary(), non_neg_integer(), non_neg_integer()) ->
+    {'ok', binary()} | {'error', atom()}.
+bpf_lookup_map_element(_Map, _Key, _ValueSize, _Flags) ->
+    not_loaded(?LINE).
+
+-spec bpf_delete_map_element(integer(), binary()) -> 'ok' | {'error', atom()}.
+bpf_delete_map_element(_Map, _Key) ->
+    not_loaded(?LINE).
+
+-spec bpf_get_map_next_key(integer(), binary()) -> {'ok', binary()} | {'error', atom()}.
+bpf_get_map_next_key(_Map, _Key) ->
+    not_loaded(?LINE).
+
+-spec bpf_test_program(integer(), integer(), binary(), non_neg_integer()) ->
+    {'ok', non_neg_integer(), binary(), non_neg_integer()} | {'error', atom()}.
+bpf_test_program(_Prog, _Repeat, _Data, _DataOutSize) ->
+    not_loaded(?LINE).
+
+-spec bpf_close(integer()) -> 'ok' | {'error', atom()}.
+bpf_close(_Fd) ->
+    not_loaded(?LINE).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+init() ->
+    SoName =
+        case code:priv_dir(?APPNAME) of
+            {error, bad_name} ->
+                case filelib:is_dir(filename:join(["..", priv])) of
+                    true ->
+                        filename:join(["..", priv, ?LIBNAME]);
+                    _ ->
+                        filename:join([priv, ?LIBNAME])
+                end;
+            Dir ->
+                filename:join(Dir, ?LIBNAME)
+        end,
+    erlang:load_nif(SoName, 0).
+
+not_loaded(Line) ->
+    erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).

--- a/src/ebpf_maps.erl
+++ b/src/ebpf_maps.erl
@@ -164,8 +164,9 @@ new(Type, KeySize, ValueSize, MaxEntries) ->
 %% @doc
 %% Returns the value associated with `Key' in eBPF map `Map' if `Map'
 %% contains `Key'.
+%%
+%% See also [http://erlang.org/doc/man/maps.html#get-2].
 %% @end
-%% @see maps:get/2
 %%--------------------------------------------------------------------
 -spec get(key(), ebpf_map()) -> value().
 get(
@@ -193,7 +194,6 @@ get(
 %% Returns the value associated with `Key' in eBPF map `Map' if `Map'
 %% contains `Key', otherwise returns `Default'.
 %% @end
-%% @see maps:get/3
 %%--------------------------------------------------------------------
 -spec get(key(), ebpf_map(), value()) -> value().
 get(
@@ -222,7 +222,6 @@ get(
 %% Returns the value associated with `Key' in eBPF map `Map' if `Map'
 %% contains `Key', otherwise returns `Default'.
 %% @end
-%% @see maps:put/3
 %%--------------------------------------------------------------------
 -spec put(key(), value(), ebpf_map()) -> ebpf_map().
 put(

--- a/src/ebpf_maps.erl
+++ b/src/ebpf_maps.erl
@@ -2,6 +2,10 @@
 %%% @author moskar <moskar.drummer@gmail.com>
 %%% @copyright (C) 2021, moskar
 %%% @doc
+%%% Creating and using eBPF maps from userspace.
+%%%
+%%% This module contains an API for eBPF maps that mimics the built-in
+%%% `maps' module.
 %%% @end
 %%% Created :  7 Feb 2021 by user <moskar.drummer@gmail.home>
 %%%-------------------------------------------------------------------

--- a/src/ebpf_maps.erl
+++ b/src/ebpf_maps.erl
@@ -14,6 +14,7 @@
     get/2,
     get/3,
     put/3,
+    remove/2,
     close/1,
     fd/1
 ]).
@@ -221,6 +222,8 @@ get(
 %% @doc
 %% Returns the value associated with `Key' in eBPF map `Map' if `Map'
 %% contains `Key', otherwise returns `Default'.
+%%
+%% See also [http://erlang.org/doc/man/maps.html#put-3].
 %% @end
 %%--------------------------------------------------------------------
 -spec put(key(), value(), ebpf_map()) -> ebpf_map().
@@ -235,6 +238,22 @@ put(
 ) when byte_size(Value) == ValueSize ->
     ok = ebpf_lib:bpf_update_map_element(Fd, to_binary(Key, KeySize), Value, 0),
     Map.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Removes the `Key', if it exists, and its associated value from `Map1'
+%% and returns a new map `Map2' without key `Key'.
+%%
+%% See also [http://erlang.org/doc/man/maps.html#remove-2].
+%% @end
+%%--------------------------------------------------------------------
+-spec remove(key(), ebpf_map()) -> ebpf_map().
+remove(Key, #bpf_map{fd = Fd, key_size = KeySize} = Map1) ->
+    case ebpf_lib:bpf_delete_map_element(Fd, to_binary(Key, KeySize)) of
+        ok -> Map1;
+        {error, enoent} -> Map1;
+        {error, Other} -> {error, Other}
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/ebpf_maps.erl
+++ b/src/ebpf_maps.erl
@@ -1,0 +1,323 @@
+%%%-------------------------------------------------------------------
+%%% @author moskar <moskar.drummer@gmail.com>
+%%% @copyright (C) 2021, moskar
+%%% @doc
+%%% @end
+%%% Created :  7 Feb 2021 by user <moskar.drummer@gmail.home>
+%%%-------------------------------------------------------------------
+-module(ebpf_maps).
+
+%% API
+-export([
+    new/4,
+    new/5,
+    get/2,
+    get/3,
+    put/3,
+    close/1,
+    fd/1
+]).
+
+-type type() ::
+    'unspec'
+    | 'hash'
+    | 'array'
+    | 'prog_array'
+    | 'perf_event_array'
+    | 'percpu_hash'
+    | 'percpu_array'
+    | 'stack_trace'
+    | 'cgroup_array'
+    | 'lru_hash'
+    | 'lru_percpu_hash'
+    | 'lpm_trie'
+    | 'array_of_maps'
+    | 'hash_of_maps'
+    | 'devmap'
+    | 'sockmap'
+    | 'cpumap'
+    | 'xskmap'
+    | 'sockhash'
+    | 'cgroup_storage'
+    | 'reuseport_sockarray'
+    | 'percpu_cgroup_storage'
+    | 'queue'
+    | 'stack'
+    | 'sk_storage'
+    | 'devmap_hash'
+    | 'struct_ops'
+    | 'ringbuf'
+    | 'inode_storage'
+    | 'task_storage'.
+%% An `atom' used to specify the type of an eBPF map, see {@link create_map/4}
+
+-type map_option() ::
+    'no_prealloc'
+    | 'read'
+    | 'write'
+    | 'zero_seed'
+    | 'prog_read'
+    | 'prog_write'
+    | 'clone'
+    | 'mmapable'.
+
+-record(bpf_map, {
+    type = unspec :: type(),
+    fd = -1 :: integer(),
+    key_size = 0 :: non_neg_integer(),
+    value_size = 0 :: non_neg_integer(),
+    max_entries = 0 :: non_neg_integer()
+}).
+-type key() :: binary() | integer().
+-type value() :: binary().
+-opaque ebpf_map() :: #bpf_map{}.
+%% An active eBPF map as returned by {@link new/5}.
+
+-export_type([ebpf_map/0]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns a new empty eBPF map.
+%%
+%% If successful, the returned map can be used from userspace via the
+%% functions in this module, as well as shared with eBPF programs e.g.
+%% via {@link ebpf_kern:ld_map_fd/2}.
+%%
+%% `KeySize' and `ValueSize' are given in octets.
+%%
+%% The following `Options' are currently supported:
+%%
+%% `no_prealloc' - The kernel will not allocate the needed memory for
+%% the map ahead of time.
+%% Defaults to `false', i.e. the map is preallocated.
+%%
+%% `read' - Limits userspace access to the map to read-only.
+%% Defaults to `false'.
+%%
+%% `write' - Limits userspace access to the map to write-only.
+%% Defaults to `false'.
+%%
+%% `zero_seed' - Initializes the map's hash function with a null seed,
+%% Which can be useful for testing.
+%% This option should not be used in production.
+%% Defaults to `false'.
+%%
+%% `prog_read' - Limits the access to the map from eBPF programs to
+%% read-only.
+%% Defaults to `false'.
+%%
+%% `prog_write' - Limits the access to the map from eBPF programs to
+%% write-only.
+%% Defaults to `false'.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec new(
+    Type :: type(),
+    KeySize :: integer(),
+    ValueSize :: integer(),
+    MaxEntries :: integer(),
+    Options :: [map_option()]
+) -> ebpf_map() | {'error', atom()}.
+new(Type, KeySize, ValueSize, MaxEntries, Options) ->
+    Flags = read_map_options(Options),
+    case
+        ebpf_lib:bpf_create_map(
+            type_to_int(Type),
+            KeySize,
+            ValueSize,
+            MaxEntries,
+            Flags
+        )
+    of
+        {ok, Fd} ->
+            #bpf_map{
+                fd = Fd,
+                key_size = KeySize,
+                value_size = ValueSize,
+                max_entries = MaxEntries
+            };
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Same as {@link new/5}, with default options.
+%% @end
+%%--------------------------------------------------------------------
+-spec new(
+    Type :: type(),
+    KeySize :: integer(),
+    ValueSize :: integer(),
+    MaxEntries :: integer()
+) -> ebpf_map() | {'error', atom()}.
+
+new(Type, KeySize, ValueSize, MaxEntries) ->
+    new(Type, KeySize, ValueSize, MaxEntries, []).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns the value associated with `Key' in eBPF map `Map' if `Map'
+%% contains `Key'.
+%% @end
+%% @see maps:get/2
+%%--------------------------------------------------------------------
+-spec get(key(), ebpf_map()) -> value().
+get(
+    Key,
+    #bpf_map{
+        fd = Fd,
+        key_size = KeySize,
+        value_size = ValueSize
+    } = _Map
+) when is_binary(Key), byte_size(Key) == KeySize ->
+    case
+        ebpf_lib:bpf_lookup_map_element(
+            Fd,
+            to_binary(Key, KeySize),
+            ValueSize,
+            0
+        )
+    of
+        {ok, Value} -> Value;
+        {error, enoent} -> throw({badkey, Key})
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns the value associated with `Key' in eBPF map `Map' if `Map'
+%% contains `Key', otherwise returns `Default'.
+%% @end
+%% @see maps:get/3
+%%--------------------------------------------------------------------
+-spec get(key(), ebpf_map(), value()) -> value().
+get(
+    Key,
+    #bpf_map{
+        fd = Fd,
+        key_size = KeySize,
+        value_size = ValueSize
+    },
+    Default
+) when byte_size(Key) == KeySize ->
+    case
+        ebpf_lib:bpf_lookup_map_element(
+            Fd,
+            Key,
+            ValueSize,
+            0
+        )
+    of
+        {ok, Value} -> Value;
+        {error, enoent} -> Default
+    end.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns the value associated with `Key' in eBPF map `Map' if `Map'
+%% contains `Key', otherwise returns `Default'.
+%% @end
+%% @see maps:put/3
+%%--------------------------------------------------------------------
+-spec put(key(), value(), ebpf_map()) -> ebpf_map().
+put(
+    Key,
+    Value,
+    #bpf_map{
+        fd = Fd,
+        key_size = KeySize,
+        value_size = ValueSize
+    } = Map
+) when byte_size(Value) == ValueSize ->
+    ok = ebpf_lib:bpf_update_map_element(Fd, to_binary(Key, KeySize), Value, 0),
+    Map.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Closes `Map'.
+%% @end
+%%--------------------------------------------------------------------
+-spec close(Map :: ebpf_map()) -> 'ok' | {'error', atom()}.
+close(Map) ->
+    ebpf_lib:bpf_close(Map#bpf_map.fd).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns a File Descriptor for `Map'.
+%%
+%% Can be used for passing a map to eBPF programs, e.g. via {@link ebpf_kern:ld_map_fd/2}.
+%% @end
+%%--------------------------------------------------------------------
+-spec fd(ebpf_map()) -> non_neg_integer().
+fd(Map) -> Map#bpf_map.fd.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+-spec read_map_options([map_option()]) -> non_neg_integer().
+read_map_options(Options) ->
+    read_map_options(Options, 0).
+
+-spec read_map_options([map_option()], non_neg_integer()) -> non_neg_integer().
+read_map_options([no_prealloc | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 0));
+read_map_options([read | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 3));
+read_map_options([write | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 4));
+read_map_options([zero_seed | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 6));
+read_map_options([prog_read | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 7));
+read_map_options([prog_write | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 8));
+read_map_options([clone | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 9));
+read_map_options([mmapable | More], Flags0) ->
+    read_map_options(More, Flags0 bor (1 bsl 10));
+read_map_options([], Flags) ->
+    Flags.
+
+-spec to_binary(key(), non_neg_integer()) -> binary().
+to_binary(Bin, Size) when is_binary(Bin), byte_size(Bin) == Size ->
+    Bin;
+to_binary(Int, Size) when is_integer(Int) ->
+    <<Int:(Size * 8)>>.
+
+-spec type_to_int(type()) -> integer().
+type_to_int(unspec) -> 0;
+type_to_int(hash) -> 1;
+type_to_int(array) -> 2;
+type_to_int(prog_array) -> 3;
+type_to_int(perf_event_array) -> 4;
+type_to_int(percpu_hash) -> 5;
+type_to_int(percpu_array) -> 6;
+type_to_int(stack_trace) -> 7;
+type_to_int(cgroup_array) -> 8;
+type_to_int(lru_hash) -> 9;
+type_to_int(lru_percpu_hash) -> 10;
+type_to_int(lpm_trie) -> 11;
+type_to_int(array_of_maps) -> 12;
+type_to_int(hash_of_maps) -> 13;
+type_to_int(devmap) -> 14;
+type_to_int(sockmap) -> 15;
+type_to_int(cpumap) -> 16;
+type_to_int(xskmap) -> 17;
+type_to_int(sockhash) -> 18;
+type_to_int(cgroup_storage) -> 19;
+type_to_int(reuseport_sockarray) -> 20;
+type_to_int(percpu_cgroup_storage) -> 21;
+type_to_int(queue) -> 22;
+type_to_int(stack) -> 23;
+type_to_int(sk_storage) -> 24;
+type_to_int(devmap_hash) -> 25;
+type_to_int(struct_ops) -> 26;
+type_to_int(ringbuf) -> 27;
+type_to_int(inode_storage) -> 28;
+type_to_int(task_storage) -> 29.

--- a/test/ebpf_SUITE.erl
+++ b/test/ebpf_SUITE.erl
@@ -316,7 +316,11 @@ test_user_map_hash_1(_Config) ->
             Value = <<5, 6, 7, 8>>,
             Map1 = ebpf_maps:put(Key, Value, Map0),
             Value = ebpf_maps:get(Key, Map1),
-            ok = ebpf_maps:close(Map1)
+            Map2 = ebpf_maps:remove(Key, Map1),
+            Default = <<"leet">>,
+            Default = ebpf_maps:get(Key, Map1, Default),
+            Map3 = ebpf_maps:remove(Key, Map2),
+            ok = ebpf_maps:close(Map3)
     end.
 
 test_user_test_program_1() -> [].

--- a/test/ebpf_SUITE.erl
+++ b/test/ebpf_SUITE.erl
@@ -301,28 +301,22 @@ readme_example_1(_Config) ->
 
 test_user_create_map_hash_1() -> [].
 test_user_create_map_hash_1(_Config) ->
-    case ebpf_user:create_map(hash, 4, 4, 255, 0) of
-        {ok, Map} -> ebpf_user:close(Map);
-        {error, eperm} -> {skip, eperm};
-        Other -> {error, Other}
+    case ebpf_maps:new(hash, 4, 4, 255) of
+        {error, Reason} -> {error, Reason};
+        Map -> ebpf_maps:close(Map)
     end.
 
 test_user_map_hash_1() -> [].
 test_user_map_hash_1(_Config) ->
-    case ebpf_user:create_map(hash, 4, 4, 5, 0) of
-        {ok, Map} ->
+    case ebpf_maps:new(hash, 4, 4, 5) of
+        {error, Reason} ->
+            {error, Reason};
+        Map0 ->
             Key = <<1, 2, 3, 4>>,
             Value = <<5, 6, 7, 8>>,
-            Flags = 0,
-            ok = ebpf_user:update_map_element(Map, Key, Value, Flags),
-            {ok, Key} = ebpf_user:get_map_next_key(Map, <<"None">>),
-            {ok, Value} = ebpf_user:lookup_map_element(Map, Key, 4, 0),
-            ok = ebpf_user:delete_map_element(Map, Key),
-            ok = ebpf_user:close(Map);
-        {error, eperm} ->
-            {skip, eperm};
-        Other ->
-            {error, Other}
+            Map1 = ebpf_maps:put(Key, Value, Map0),
+            Value = ebpf_maps:get(Key, Map1),
+            ok = ebpf_maps:close(Map1)
     end.
 
 test_user_test_program_1() -> [].
@@ -498,8 +492,8 @@ test_load_cf_ttl_1(_Config) ->
     %   "12: (85) call bpf_map_lookup_elem#1\n"
     %   "13: safe\n"
     %   "processed 33 insns (limit 131072), stack depth 16\n",
-    {ok, Map} = ebpf_user:create_map(hash, 4, 8, 4, 0),
-    MapFd = ebpf_user:fd(Map),
+    Map = ebpf_maps:new(hash, 4, 8, 4),
+    MapFd = ebpf_maps:fd(Map),
     Instructions = lists:flatten([
         ebpf_kern:ldx_mem(w, 0, 1, 16),
         ebpf_kern:jmp64_imm(eq, 0, 16#86DD, 3),
@@ -534,12 +528,13 @@ test_load_cf_ttl_1(_Config) ->
         sleepable
     ]),
     Expected = lists:sublist(Desc, length(Expected)),
-    ok = ebpf_user:close(Prog).
+    ok = ebpf_user:close(Prog),
+    ok = ebpf_maps:close(Map).
 
 test_load_cf_ttl_2() -> [].
 test_load_cf_ttl_2(_Config) ->
-    {ok, Map} = ebpf_user:create_map(hash, 4, 8, 4, 0),
-    MapFd = ebpf_user:fd(Map),
+    Map = ebpf_maps:new(hash, 4, 8, 4),
+    MapFd = ebpf_maps:fd(Map),
     Instructions = lists:flatten([
         ebpf_kern:ldx_mem(w, 0, 1, 16),
         ebpf_kern:jmp64_imm(eq, 0, 16#86DD, 3),
@@ -573,4 +568,5 @@ test_load_cf_ttl_2(_Config) ->
         ebpf_asm:assemble(Instructions),
         [{log_buffer_size, 0}]
     ),
-    ok = ebpf_user:close(Prog).
+    ok = ebpf_user:close(Prog),
+    ok = ebpf_maps:close(Map).


### PR DESCRIPTION
Part of #41 

This PR adds the `ebpf_maps` module, an API for userspace interaction with eBPF maps that mimics the built-in `maps` module.
Some functions that dealt with eBPF maps are moved from `ebpf_user`, which is dedicated to eBPF _programs_, to the new maps module.