### PR TITLE
Add ebpf_user:attach/2

### DIFF
--- a/c_src/bpf.c
+++ b/c_src/bpf.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
 #include <stdlib.h>
 #include <string.h>
 #include <memory.h>

--- a/c_src/bpf.h
+++ b/c_src/bpf.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
 #ifndef __BPF_H
 #define __BPF_H
 

--- a/c_src/bpf_endian.h
+++ b/c_src/bpf_endian.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
 #ifndef __BPF_ENDIAN__
 #define __BPF_ENDIAN__
 

--- a/c_src/netlink.c
+++ b/c_src/netlink.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
 #include <stdlib.h>
 #include <memory.h>
 #include <unistd.h>

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -12,6 +12,7 @@ with eBPF programs.
   <li>{@section Introduction}</li>
   <li>{@section Generating eBPF code}</li>
   <li>{@section Interacting with eBPF programs}</li>
+  <li>{@section Interacting with eBPF maps}</li>
 </ol>
 
 == Introduction ==
@@ -36,5 +37,16 @@ See {@link ebpf_kern}.
 
 See {@link ebpf_user}.
 
+== Interacting with eBPF maps ==
+
+eBPF maps are the main method of keeping state and communicating with userspace
+in eBPF programs.
+The standard workflow with eBPF maps is creating and initializing a map `Map' from
+userspace, then loading an eBPF program `Prog' that accesses `Map', e.g.
+to read some configuration data, and then using from userspace `Map' to interact
+with `Prog', e.g. by updating the configuration stored in `Map' or reading values
+that `Prog' may have updated.
+
+For the interacting with eBPF maps from userspace, see {@link ebpf_maps}.
 
 @end

--- a/test/ebpf_SUITE.erl
+++ b/test/ebpf_SUITE.erl
@@ -253,7 +253,7 @@ simple_socket_filter_1(_Config) ->
         ])
     ),
     {ok, Sock} = socket:open(inet, stream, {raw, 0}),
-    ok = ebpf_user:attach_socket_filter(Sock, Prog),
+    ok = ebpf_user:attach(Sock, Prog),
     ok = ebpf_user:detach_socket_filter(Sock),
     ok = ebpf_user:close(Prog),
     ok = socket:close(Sock).
@@ -269,7 +269,7 @@ simple_xdp_1(_Config) ->
             ebpf_kern:exit_insn()
         ])
     ),
-    ok = ebpf_user:attach_xdp("lo", Prog),
+    ok = ebpf_user:attach("lo", Prog),
     ok = ebpf_user:detach_xdp("lo"),
     ok = ebpf_user:close(Prog).
 
@@ -286,7 +286,7 @@ readme_example_1(_Config) ->
     {ok, FilterProg} = ebpf_user:load(socket_filter, BinProg),
     {ok, Sock} = socket:open(inet, stream, {raw, 0}),
     % All new input to Sock is
-    ok = ebpf_user:attach_socket_filter(Sock, FilterProg),
+    ok = ebpf_user:attach(Sock, FilterProg),
     % Sock is back to normal and FilterProg can be
     ok = ebpf_user:detach_socket_filter(Sock),
 
@@ -295,7 +295,7 @@ readme_example_1(_Config) ->
 
     {ok, XdpProg} = ebpf_user:load(xdp, BinProg),
     % Try pinging 127.0.0.1, go ahead
-    ok = ebpf_user:attach_xdp("lo", XdpProg),
+    ok = ebpf_user:attach("lo", XdpProg),
     % Now, that's better :)
     ok = ebpf_user:detach_xdp("lo"),
     ok = ebpf_user:close(XdpProg).


### PR DESCRIPTION
Part of #41 
This PR merges the `ebpf_user:attach_*/2` functions to a single `ebpf_user:attach/2` API function.
The type of the attach point is determined by the type of the given program.