### PR TITLE
Use atoms rather than integers to represent eBPF registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ A minimal example is given below:
 ```erlang
 BinProg = ebpf_asm:assemble([
                 % Drop all packets
-                ebpf_kern:mov64_imm(0, 0), % r0 = 0
-                ebpf_kern:exit_insn()      % return r0
+                ebpf_kern:mov64_imm(r0, 0), % r0 = 0
+                ebpf_kern:exit_insn()       % return r0
             ]),
 
 {ok, FilterProg} = ebpf_user:load(socket_filter, BinProg),

--- a/include/ebpf_kern.hrl
+++ b/include/ebpf_kern.hrl
@@ -75,8 +75,8 @@
 -define(BPF_TAX, 16#00).
 -define(BPF_TXA, 16#80).
 
--define(BPF_PSEUDO_MAP_FD, 1).
--define(BPF_PSEUDO_MAP_VALUE, 2).
+-define(BPF_PSEUDO_MAP_FD, r1).
+-define(BPF_PSEUDO_MAP_VALUE, r2).
 
 -type bpf_ld_mode() :: 'imm' | 'abs' | 'mem' | 'ind' | 'xadd'.
 
@@ -288,14 +288,14 @@
     {bpf_ld_st_class(), bpf_size(), bpf_ld_mode()}
     | {bpf_alu_class(), bpf_src(), bpf_alu_op()}
     | {bpf_jmp_class(), bpf_src(), bpf_jmp_op()}.
--type bpf_reg() :: 0..10.
+-type bpf_reg() :: 'r0' | 'r1' | 'r2' | 'r3' | 'r4' | 'r5' | 'r6' | 'r7' | 'r8' | 'r9' | 'r10'.
 -type bpf_off() :: 1 - (1 bsl 15)..(1 bsl 15) - 1.
 -type bpf_imm() :: 1 - (1 bsl 31)..(1 bsl 31) - 1.
 
 -record(bpf_instruction, {
-    code = 0 :: bpf_opcode(),
-    dst_reg = 0 :: bpf_reg(),
-    src_reg = 0 :: bpf_reg(),
+    code = {ld, w, imm} :: bpf_opcode(),
+    dst_reg = r0 :: bpf_reg(),
+    src_reg = r0 :: bpf_reg(),
     off = 0 :: bpf_off(),
     imm = 0 :: bpf_imm()
 }).

--- a/src/ebpf_asm.erl
+++ b/src/ebpf_asm.erl
@@ -61,12 +61,14 @@ bpf_instructions_to_binary(BpfInstructions) ->
 -spec bpf_instruction_encode(bpf_instruction()) -> binary().
 bpf_instruction_encode(#bpf_instruction{
     code = OpCode,
-    dst_reg = Dst,
-    src_reg = Src,
+    dst_reg = DstReg,
+    src_reg = SrcReg,
     off = Off,
     imm = Imm
 }) ->
     Code = bpf_opcode_to_int(OpCode),
+    Dst = bpf_reg_to_int(DstReg),
+    Src = bpf_reg_to_int(SrcReg),
     <<Code:8/unsigned, Src:4/unsigned, Dst:4/unsigned, Off:16/little-signed, Imm:32/little-signed>>.
 
 -spec bpf_instruction_decode(binary()) -> bpf_instruction().
@@ -75,8 +77,8 @@ bpf_instruction_decode(
 ) ->
     #bpf_instruction{
         code = bpf_opcode_from_int(Code),
-        dst_reg = Dst,
-        src_reg = Src,
+        dst_reg = bpf_reg_from_int(Dst),
+        src_reg = bpf_reg_from_int(Src),
         off = Off,
         imm = Imm
     }.
@@ -215,3 +217,29 @@ bpf_jmp_op_to_int(slt) -> ?BPF_JSLT;
 bpf_jmp_op_to_int(sle) -> ?BPF_JSLE;
 bpf_jmp_op_to_int(call) -> ?BPF_CALL;
 bpf_jmp_op_to_int(exit) -> ?BPF_EXIT.
+
+-spec bpf_reg_from_int(byte()) -> bpf_reg().
+bpf_reg_from_int(0) -> r0;
+bpf_reg_from_int(1) -> r1;
+bpf_reg_from_int(2) -> r2;
+bpf_reg_from_int(3) -> r3;
+bpf_reg_from_int(4) -> r4;
+bpf_reg_from_int(5) -> r5;
+bpf_reg_from_int(6) -> r6;
+bpf_reg_from_int(7) -> r7;
+bpf_reg_from_int(8) -> r8;
+bpf_reg_from_int(9) -> r9;
+bpf_reg_from_int(10) -> r10.
+
+-spec bpf_reg_to_int(bpf_reg()) -> byte().
+bpf_reg_to_int(r0) -> 0;
+bpf_reg_to_int(r1) -> 1;
+bpf_reg_to_int(r2) -> 2;
+bpf_reg_to_int(r3) -> 3;
+bpf_reg_to_int(r4) -> 4;
+bpf_reg_to_int(r5) -> 5;
+bpf_reg_to_int(r6) -> 6;
+bpf_reg_to_int(r7) -> 7;
+bpf_reg_to_int(r8) -> 8;
+bpf_reg_to_int(r9) -> 9;
+bpf_reg_to_int(r10) -> 10.

--- a/src/ebpf_kern.erl
+++ b/src/ebpf_kern.erl
@@ -395,9 +395,9 @@ stack_printk(String, StackHead) ->
     Instructions =
         Instructions0 ++
             [
-                mov64_reg(1, 10),
-                alu64_imm(add, 1, NewStackHead),
-                mov64_imm(2, -NewStackHead),
+                mov64_reg(r1, r10),
+                alu64_imm(add, r1, NewStackHead),
+                mov64_imm(r2, -NewStackHead),
                 call_helper(trace_printk)
             ],
     Instructions.
@@ -450,7 +450,7 @@ store_buffer(Bin, Off) ->
 
 -spec store_buffer(binary(), integer(), [bpf_instruction()]) -> [bpf_instruction()].
 store_buffer(<<Imm:32/big-signed-integer, Bin/binary>>, Off, Acc) ->
-    store_buffer(Bin, Off + 4, [st_mem(w, 10, Off, Imm) | Acc]);
+    store_buffer(Bin, Off + 4, [st_mem(w, r10, Off, Imm) | Acc]);
 store_buffer(<<>>, _Off, Acc) ->
     Acc;
 store_buffer(BinImm, Off, Acc) ->

--- a/test/ebpf_SUITE.erl
+++ b/test/ebpf_SUITE.erl
@@ -247,7 +247,7 @@ simple_socket_filter_1(_Config) ->
         socket_filter,
         ebpf_asm:assemble([
             % R0 = 0
-            ebpf_kern:mov64_imm(0, 0),
+            ebpf_kern:mov64_imm(r0, 0),
             % return R0
             ebpf_kern:exit_insn()
         ])
@@ -264,7 +264,7 @@ simple_xdp_1(_Config) ->
         xdp,
         ebpf_asm:assemble([
             % R0 = 0
-            ebpf_kern:mov64_imm(0, 0),
+            ebpf_kern:mov64_imm(r0, 0),
             % return R0
             ebpf_kern:exit_insn()
         ])
@@ -279,7 +279,7 @@ readme_example_1(_Config) ->
         % Drop all packets
 
         % r0 = 0
-        ebpf_kern:mov64_imm(0, 0),
+        ebpf_kern:mov64_imm(r0, 0),
         % return r0
         ebpf_kern:exit_insn()
     ]),
@@ -370,7 +370,7 @@ test_user_test_program_1(_Config) ->
             xdp,
             ebpf_asm:assemble(
                 lists:flatten([
-                    ebpf_kern:mov64_imm(0, -1),
+                    ebpf_kern:mov64_imm(r0, -1),
                     ebpf_kern:exit_insn()
                 ])
             )
@@ -402,7 +402,7 @@ test_user_test_program_2(_Config) ->
             xdp,
             ebpf_asm:assemble(
                 lists:flatten([
-                    ebpf_kern:mov64_imm(0, -1),
+                    ebpf_kern:mov64_imm(r0, -1),
                     ebpf_kern:exit_insn()
                 ])
             )
@@ -432,12 +432,12 @@ alu64_reg_known_good_result_1() -> [].
 alu64_reg_known_good_result_1(_Config) ->
     #bpf_instruction{
         code = {alu64, x, add},
-        dst_reg = 1,
-        src_reg = 2
+        dst_reg = r1,
+        src_reg = r2
     } = ebpf_kern:alu64_reg(
         add,
-        1,
-        2
+        r1,
+        r2
     ).
 
 ld_imm64_raw_full_known_good_result_1() -> [].
@@ -445,21 +445,21 @@ ld_imm64_raw_full_known_good_result_1(_Config) ->
     [
         #bpf_instruction{
             code = {ld, dw, imm},
-            dst_reg = 1,
-            src_reg = 2,
+            dst_reg = r1,
+            src_reg = r2,
             off = 1337,
             imm = 16#beef
         },
         #bpf_instruction{
             code = {ld, w, imm},
-            dst_reg = 0,
-            src_reg = 0,
+            dst_reg = r0,
+            src_reg = r0,
             off = 8008,
             imm = 16#feed
         }
     ] = ebpf_kern:ld_imm64_raw_full(
-        1,
-        2,
+        r1,
+        r2,
         1337,
         8008,
         16#beef,
@@ -471,19 +471,19 @@ ld_map_fd_known_good_result_1(_Config) ->
     [
         #bpf_instruction{
             code = {ld, dw, imm},
-            dst_reg = 1,
+            dst_reg = r1,
             src_reg = ?BPF_PSEUDO_MAP_FD,
             off = 0,
             imm = 17
         },
         #bpf_instruction{
             code = {ld, w, imm},
-            dst_reg = 0,
-            src_reg = 0,
+            dst_reg = r0,
+            src_reg = r0,
             off = 0,
             imm = 0
         }
-    ] = ebpf_kern:ld_map_fd(1, 17).
+    ] = ebpf_kern:ld_map_fd(r1, 17).
 
 test_load_cf_ttl_1() -> [].
 test_load_cf_ttl_1(_Config) ->
@@ -533,31 +533,31 @@ test_load_cf_ttl_1(_Config) ->
     Map = ebpf_maps:new(hash, 4, 8, 4),
     MapFd = ebpf_maps:fd(Map),
     Instructions = lists:flatten([
-        ebpf_kern:ldx_mem(w, 0, 1, 16),
-        ebpf_kern:jmp64_imm(eq, 0, 16#86DD, 3),
-        ebpf_kern:mov64_reg(6, 1),
+        ebpf_kern:ldx_mem(w, r0, r1, 16),
+        ebpf_kern:jmp64_imm(eq, r0, 16#86DD, 3),
+        ebpf_kern:mov64_reg(r6, r1),
         ebpf_kern:ld_abs(b, -16#100000 + 8),
         ebpf_kern:jmp_a(2),
-        ebpf_kern:mov64_reg(6, 1),
+        ebpf_kern:mov64_reg(r6, r1),
         ebpf_kern:ld_abs(b, -16#100000 + 7),
-        ebpf_kern:stx_mem(w, 10, 0, -4),
-        ebpf_kern:mov64_reg(2, 10),
-        ebpf_kern:alu64_imm(add, 2, -4),
-        ebpf_kern:ld_map_fd(1, MapFd),
+        ebpf_kern:stx_mem(w, r10, r0, -4),
+        ebpf_kern:mov64_reg(r2, r10),
+        ebpf_kern:alu64_imm(add, r2, -4),
+        ebpf_kern:ld_map_fd(r1, MapFd),
         ebpf_kern:call_helper(map_lookup_elem),
-        ebpf_kern:jmp64_imm(eq, 0, 0, 3),
-        ebpf_kern:mov64_imm(1, 1),
-        ebpf_kern:stx_xadd(dw, 0, 1, 0),
+        ebpf_kern:jmp64_imm(eq, r0, 0, 3),
+        ebpf_kern:mov64_imm(r1, 1),
+        ebpf_kern:stx_xadd(dw, r0, r1, 0),
         ebpf_kern:jmp_a(9),
-        ebpf_kern:ld_map_fd(1, MapFd),
-        ebpf_kern:mov64_reg(2, 10),
-        ebpf_kern:alu64_imm(add, 2, -4),
-        ebpf_kern:st_mem(dw, 10, -16, 1),
-        ebpf_kern:mov64_reg(3, 10),
-        ebpf_kern:alu64_imm(add, 3, -16),
-        ebpf_kern:mov64_imm(4, 0),
+        ebpf_kern:ld_map_fd(r1, MapFd),
+        ebpf_kern:mov64_reg(r2, r10),
+        ebpf_kern:alu64_imm(add, r2, -4),
+        ebpf_kern:st_mem(dw, r10, -16, 1),
+        ebpf_kern:mov64_reg(r3, r10),
+        ebpf_kern:alu64_imm(add, r3, -16),
+        ebpf_kern:mov64_imm(r4, 0),
         ebpf_kern:call_helper(map_update_elem),
-        ebpf_kern:mov64_imm(0, -1),
+        ebpf_kern:mov64_imm(r0, -1),
         ebpf_kern:exit_insn()
     ]),
     {ok, Prog, Desc} = ebpf_user:load(socket_filter, ebpf_asm:assemble(Instructions), [
@@ -574,31 +574,31 @@ test_load_cf_ttl_2(_Config) ->
     Map = ebpf_maps:new(hash, 4, 8, 4),
     MapFd = ebpf_maps:fd(Map),
     Instructions = lists:flatten([
-        ebpf_kern:ldx_mem(w, 0, 1, 16),
-        ebpf_kern:jmp64_imm(eq, 0, 16#86DD, 3),
-        ebpf_kern:mov64_reg(6, 1),
+        ebpf_kern:ldx_mem(w, r0, r1, 16),
+        ebpf_kern:jmp64_imm(eq, r0, 16#86DD, 3),
+        ebpf_kern:mov64_reg(r6, r1),
         ebpf_kern:ld_abs(b, -16#100000 + 8),
         ebpf_kern:jmp_a(2),
-        ebpf_kern:mov64_reg(6, 1),
+        ebpf_kern:mov64_reg(r6, r1),
         ebpf_kern:ld_abs(b, -16#100000 + 7),
-        ebpf_kern:stx_mem(w, 10, 0, -4),
-        ebpf_kern:mov64_reg(2, 10),
-        ebpf_kern:alu64_imm(add, 2, -4),
-        ebpf_kern:ld_map_fd(1, MapFd),
+        ebpf_kern:stx_mem(w, r10, r0, -4),
+        ebpf_kern:mov64_reg(r2, r10),
+        ebpf_kern:alu64_imm(add, r2, -4),
+        ebpf_kern:ld_map_fd(r1, MapFd),
         ebpf_kern:call_helper(map_lookup_elem),
-        ebpf_kern:jmp64_imm(eq, 0, 0, 3),
-        ebpf_kern:mov64_imm(1, 1),
-        ebpf_kern:stx_xadd(dw, 0, 1, 0),
+        ebpf_kern:jmp64_imm(eq, r0, 0, 3),
+        ebpf_kern:mov64_imm(r1, 1),
+        ebpf_kern:stx_xadd(dw, r0, r1, 0),
         ebpf_kern:jmp_a(9),
-        ebpf_kern:ld_map_fd(1, MapFd),
-        ebpf_kern:mov64_reg(2, 10),
-        ebpf_kern:alu64_imm(add, 2, -4),
-        ebpf_kern:st_mem(dw, 10, -16, 1),
-        ebpf_kern:mov64_reg(3, 10),
-        ebpf_kern:alu64_imm(add, 3, -16),
-        ebpf_kern:mov64_imm(4, 0),
+        ebpf_kern:ld_map_fd(r1, MapFd),
+        ebpf_kern:mov64_reg(r2, r10),
+        ebpf_kern:alu64_imm(add, r2, -4),
+        ebpf_kern:st_mem(dw, r10, -16, 1),
+        ebpf_kern:mov64_reg(r3, r10),
+        ebpf_kern:alu64_imm(add, r3, -16),
+        ebpf_kern:mov64_imm(r4, 0),
         ebpf_kern:call_helper(map_update_elem),
-        ebpf_kern:mov64_imm(0, -1),
+        ebpf_kern:mov64_imm(r0, -1),
         ebpf_kern:exit_insn()
     ]),
     {ok, Prog} = ebpf_user:load(

--- a/test/prop_ebpf.erl
+++ b/test/prop_ebpf.erl
@@ -34,7 +34,7 @@ prop_kern_exit_returns_given_value() ->
             Data = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>,
             {ok, Prog} = ebpf_user:load(
                 xdp,
-                ebpf_asm:assemble([ebpf_kern:mov64_imm(0, Val), ebpf_kern:exit_insn()])
+                ebpf_asm:assemble([ebpf_kern:mov64_imm(r0, Val), ebpf_kern:exit_insn()])
             ),
             {ok, Val, Data, _Duration1} = ebpf_user:test(Prog, 1, Data, byte_size(Data)),
             {ok, Val, <<>>, _Duration2} = ebpf_user:test(Prog, 1, Data, 0),


### PR DESCRIPTION
Part of #41 .

Using integers for registers, offsets and immediate values in `ebpf_kern` can lead to confusing calls, like
```erlang
ebpf_kern:mov64_imm(0, 1)
```
The problem is that it's hard to tell by looking at the code whether that line means `r0 = 1` or `r1 = 0`.  

This PR changes the `bpf_reg()` type the atoms `r0, r1, ..., r10` instead of the numeric values of the registers.
Hence, after this PR instead of  `mov64_imm(0, 1)` we have 
```erlang
ebpf_kern:mov64_imm(r0, 1)
```
which does not suffer from the same ambiguity.

