### PR TITLE
Makefile: make sure erl stops *after* print.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -7,9 +7,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 # PROJECT := $(strip $(PROJECT))
 PROJECT = ebpf_lib
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)])." -s erlang halt)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, lib)])." -s erlang halt)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so


### PR DESCRIPTION
In Erlang 26, `-s init stop` before `-eval` causes the eval part to fail. Per [documentation](https://www.erlang.org/doc/man/init.html), `-eval expressions are evaluated sequentially with -s and -run function calls (this also in the order specified)`, so stop before eval is a race condition that started to fail.